### PR TITLE
Fix ConnectionError, as it does not contain the 'message' attribute

### DIFF
--- a/purestorage/purestorage.py
+++ b/purestorage/purestorage.py
@@ -164,7 +164,7 @@ class FlashArray(object):
         except requests.exceptions.RequestException as err:
             # error outside scope of HTTP status codes
             # e.g. unable to resolve domain name
-            raise PureError(err.message)
+            raise PureError(err.args[0])
 
         if response.status_code == 200:
             if "application/json" in response.headers.get("Content-Type", ""):


### PR DESCRIPTION
The ConnectionError object from request.exceptions.RequestException does not contain the 'message' attribute. This causes and exception when trying to handle these exceptions. Fixed by using 'args' to get the inner exception.