### PR TITLE
Fix exception handling when SSL certificate can't be verified.

### DIFF
--- a/purestorage/purestorage.py
+++ b/purestorage/purestorage.py
@@ -166,7 +166,7 @@ class FlashArray(object):
         except requests.exceptions.RequestException as err:
             # error outside scope of HTTP status codes
             # e.g. unable to resolve domain name
-            raise PureError(err.message)
+            raise PureError(err)
 
         if response.status_code == 200:
             if "application/json" in response.headers.get("Content-Type", ""):


### PR DESCRIPTION
Without the fix FlashArray() call fails with:

...
  File ".../.venv/lib64/python3.6/site-packages/purestorage/purestorage.py", line 169, in _request
    raise PureError(err.message)
AttributeError: 'SSLError' object has no attribute 'message'