### PR TITLE
Silence InsecureRequestWarning if verify_https=False

### DIFF
--- a/purestorage/purestorage.py
+++ b/purestorage/purestorage.py
@@ -133,6 +133,10 @@ class FlashArray(object):
             else:
                 self._request_kwargs["verify"] = verify_https
 
+        if not verify_https:
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
         self._user_agent = user_agent
 
         self._rest_version = rest_version


### PR DESCRIPTION
The default is not to verify SSL certificates which then results in the below warnings being printed:

.venv/lib64/python3.6/site-packages/urllib3/connectionpool.py:1004: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,

Which is rather not user/developer friendly.
